### PR TITLE
Fix bug: wrong nvml function behaviour

### DIFF
--- a/src/nvml_entry.c
+++ b/src/nvml_entry.c
@@ -1547,7 +1547,7 @@ nvmlGpuInstanceCreateComputeInstance(nvmlGpuInstance_t gpuInstance,
 }
 
 nvmlReturn_t nvmlGpuInstanceDestroy(nvmlGpuInstance_t gpuInstance) {
-  return NVML_ENTRY_CALL(cuda_library_entry, nvmlGpuInstanceDestroy,
+  return NVML_ENTRY_CALL(nvml_library_entry, nvmlGpuInstanceDestroy,
                          gpuInstance);
 }
 


### PR DESCRIPTION
Fix bug: the nvml function should find the symbol from nvml_library_entry instead of cuda_library_entry